### PR TITLE
Need to specify TF1.x

### DIFF
--- a/tutorial_deep_learning_basics/deep_learning_basics.ipynb
+++ b/tutorial_deep_learning_basics/deep_learning_basics.ipynb
@@ -93,6 +93,7 @@
    ],
    "source": [
     "# TensorFlow and tf.keras\n",
+    "%tensorflow_version 1.x\n",
     "import tensorflow as tf\n",
     "from tensorflow import keras\n",
     "from tensorflow.keras.layers import Conv2D, MaxPooling2D, Dropout, Flatten, Dense\n",


### PR DESCRIPTION
This will not run on TF2 due to the fact that tf.train.AdamOptimizer is not available in TF2.
Hence, I am proposing this minor change to ensure TF1.x is selected when the model is built.