### PR TITLE
fix tensorflow api version evolution issue

### DIFF
--- a/tutorial_deep_learning_basics/deep_learning_basics.ipynb
+++ b/tutorial_deep_learning_basics/deep_learning_basics.ipynb
@@ -522,7 +522,7 @@
    },
    "outputs": [],
    "source": [
-    "model.compile(optimizer=tf.train.AdamOptimizer(), \n",
+    "model.compile(optimizer=tf.optimizers.Adam(), \n",
     "              loss='sparse_categorical_crossentropy',\n",
     "              metrics=['accuracy'])"
    ]


### PR DESCRIPTION
minor tweak to get running w/current versions of toolset since initial checkin.  Thanks-- awesome hands on primer. Now i can crank Hendrix - 'Are you Experienced' and do some deeeeep learning. 

And Lex, goes w/out saying love the podcasts. On that note, beyond the scope of the code though maybe you can ask some big brains with whom <or which, to extent they're not of human origin> you have close encounters to share their thoughts on whether tic tac(s) imply success at implementation of the Alcubierre Warp Drive (such that >c travel is now possible across interstellar distances via inducing ‘inflation’ astern while experiencing neither acceleration <consistent Zero g>, nor time dilation, within the warp bubble-- essentially warping SpaceTime). And if so, how they might explain working out some accompanying kinks... additionally facilitating 'low' earthly speeds, and mitigation for what would seem should be one hell of a 'wake'... 
<maybe i can be a fly-on-the-wall via a ClubHouse invite for me @W1ndH2O woot woot> 

Thanks for all you're doing! 