### PR TITLE
Fixed typo

### DIFF
--- a/tutorial_deep_learning_basics/deep_learning_basics.ipynb
+++ b/tutorial_deep_learning_basics/deep_learning_basics.ipynb
@@ -119,7 +119,7 @@
    "source": [
     "## Part 1: Boston Housing Price Prediction with Feed Forward Neural Networks\n",
     "\n",
-    "Let's start with using a fully-connected neural network to do predict housing prices. The following image highlights the difference between regression and classification (see part 2). Given an observation as input, **regression** outputs a continuous value (e.g., exact temperature) and classificaiton outputs a class/category that the observation belongs to.\n",
+    "Let's start with using a fully-connected neural network to do predict housing prices. The following image highlights the difference between regression and classification (see part 2). Given an observation as input, **regression** outputs a continuous value (e.g., exact temperature) and classification outputs a class/category that the observation belongs to.\n",
     "\n",
     "<img src=\"https://i.imgur.com/vvSoAzg.jpg\" alt=\"classification_regression\" width=\"400\"/>\n",
     "\n",


### PR DESCRIPTION
"Classification" was originally misspelled "classificaiton."